### PR TITLE
Fix bug in case-sensitive filesystems

### DIFF
--- a/index.html
+++ b/index.html
@@ -27,6 +27,6 @@
     <div id="app" style="width: 100%;height: 100%"></div>
   </body>
   <script>
-    require('./dist/app.js')
+    require('./dist/App.js')
   </script>
 </html>


### PR DESCRIPTION
Babel transpiles the source files to the './dist' folder with the first character beeing uppercase.
In case-sensitive file systems a reference with lowercase won't work.