### PR TITLE
Typo in main menu

### DIFF
--- a/src/ui/EclipseTwo.ts
+++ b/src/ui/EclipseTwo.ts
@@ -94,7 +94,7 @@ class EclipseTwo extends HTMLElement {
         this.headerList.appendChild(li1);
         const a1 = document.createElement('a');
         a1.href = '#';
-        a1.appendChild(document.createTextNode('Ecilpse Two'));
+        a1.appendChild(document.createTextNode('Eclipse Two'));
         li1.appendChild(a1);
 
         const codePage = this.extensions['eclipse-code'].pageProviders['code-page'].create();


### PR DESCRIPTION
Hi Doug,

I'm learning about Electron thanks to your Eclipse Two package.
Here's a little fix for it.  Branding is everything :-)

P.S. I actually like that you've been calling it just "Two" recently.  That's catchy.